### PR TITLE
Provide udid to callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,11 @@ This can be used to
 
 To run a shell script, just use ```system('./script.sh')```.
 ```ruby
-setup_for_device_change do |device| 
-  puts "Preparing device: #{device}"
+setup_for_device_change do |device, udid|
+  puts "Preparing device: #{device} with udid #{udid}"
+
+  # Completely reset the device before we start taking screenshots
+  system("xcrun simctl erase #{udid}")
 end
 
 setup_for_language_change do |lang, device|

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -51,14 +51,15 @@ module Snapshot
       FileUtils.mkdir_p(TRACE_DIR)
     end
 
-    def reinstall_app(device, language)
-      def find_simulator(name) # fetches the UDID of the simulator type
-        all = `instruments -s`.split("\n")
-        all.each do |current|
-          return current.match(/\[(.*)\]/)[1] if current.include?name
-        end
-        raise "Could not find simulator '#{name}' to install the app on."
+    def udid_for_simulator(name) # fetches the UDID of the simulator type
+      all = `instruments -s`.split("\n")
+      all.each do |current|
+        return current.match(/\[(.*)\]/)[1] if current.include?name
       end
+      raise "Could not find simulator '#{name}' to install the app on."
+    end
+
+    def reinstall_app(device, language)
 
       def app_identifier
         @app_identifier ||= (ENV["SNAPSHOT_APP_IDENTIFIER"] || `/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' /tmp/snapshot/build/*.app/*.plist`)
@@ -70,7 +71,7 @@ module Snapshot
         puts result if result.to_s.length > 0
       end
 
-      udid = find_simulator(device)
+      udid = udid_for_simulator(device)
       com("killall 'iOS Simulator'")
       com("xcrun simctl boot '#{udid}'")
       com("xcrun simctl uninstall '#{udid}' '#{app_identifier}'")

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -15,7 +15,7 @@ module Snapshot
 
       SnapshotConfig.shared_instance.devices.each do |device|
         
-        SnapshotConfig.shared_instance.blocks[:setup_for_device_change].call(device)  # Callback
+        SnapshotConfig.shared_instance.blocks[:setup_for_device_change].call(device, udid_for_simulator(device))  # Callback
 
         SnapshotConfig.shared_instance.languages.each do |language|
           SnapshotConfig.shared_instance.blocks[:setup_for_language_change].call(language, device) # Callback


### PR DESCRIPTION
A quick and dirty method of providing the UDID to the callback, so that the Simulator can be reset if needed.
