### PR TITLE
This should fix issue #26

### DIFF
--- a/lib/snapshot/builder.rb
+++ b/lib/snapshot/builder.rb
@@ -70,6 +70,7 @@ module Snapshot
           "CONFIGURATION_BUILD_DIR='#{BUILD_DIR}/build'",
           "-#{proj_key} '#{proj_path}'",
           "-scheme '#{scheme}'",
+          "-destination 'platform=iOS Simulator,name=iPad,OS=latest'",
           "DSTROOT='#{BUILD_DIR}'",
           "OBJROOT='#{BUILD_DIR}'",
           "SYMROOT='#{BUILD_DIR}'",


### PR DESCRIPTION
This should be better tested first, but in my case it solves the issue #26. My app is iPad only, so I can't test if it also works for the iPhone. I tried removing the name but then xctool throwed an exception.
