### PR TITLE
Added support for custom arguments to the build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,13 @@ ios_version "9.0"
 ```
 
 ### Custom Args for the build command
-
+Use the ```custom_args``` directive to prepend custom statements to the build command.
 ```ruby
 custom_args "GCC_PREPROCESSOR_DEFINITIONS='SCREENSHOTS'"
+```
+Add a ```custom_build_args``` line to your ```Snapfile``` to add custom arguments to the build command.
+```ruby
+custom_build_args "-configuration release"
 ```
 
 ### Custom Build Command
@@ -247,8 +251,8 @@ build_command "xcodebuild DSTROOT='/tmp/snapshot' OBJROOT='/tmp/snapshot' SYMROO
 ```
 
 ### Custom callbacks to prepare your app
-Run your own script when ```snapshot``` switches the simulator type or the language. 
-This can be used to 
+Run your own script when ```snapshot``` switches the simulator type or the language.
+This can be used to
 - Logout the user
 - Reset all user defaults
 - Pre-fill the database

--- a/lib/snapshot/builder.rb
+++ b/lib/snapshot/builder.rb
@@ -59,6 +59,8 @@ module Snapshot
         proj_key = 'workspace' if proj_path.end_with?'.xcworkspace'
 
         pre_command = SnapshotConfig.shared_instance.custom_args || ENV["SNAPSHOT_CUSTOM_ARGS"] || ''
+        custom_build_args = SnapshotConfig.shared_instance.custom_build_args || ENV["SNAPSHOT_CUSTOM_BUILD_ARGS"] || ''
+        
         build_command = pre_command + ' ' + (DependencyChecker.xctool_installed? ? 'xctool' : 'xcodebuild')
 
         actions = []
@@ -74,6 +76,7 @@ module Snapshot
           "DSTROOT='#{BUILD_DIR}'",
           "OBJROOT='#{BUILD_DIR}'",
           "SYMROOT='#{BUILD_DIR}'",
+          custom_build_args,
           actions.join(' ')
         ].join(' ')
       end

--- a/lib/snapshot/snapshot_config.rb
+++ b/lib/snapshot/snapshot_config.rb
@@ -36,6 +36,9 @@ module Snapshot
 
     # @return (String) This will be prepended before the actual build command
     attr_accessor :custom_args
+    
+    # @return (String) This will be appended to the actual build command
+    attr_accessor :custom_build_args
 
     # @return (Hash) All the blocks, which are called on specific actions
     attr_accessor :blocks

--- a/lib/snapshot/snapshot_file.rb
+++ b/lib/snapshot/snapshot_file.rb
@@ -47,6 +47,9 @@ module Snapshot
         when :custom_args
           raise "custom_args has to be an String".red unless value.kind_of?String
           @config.custom_args = value
+        when :custom_build_args
+          raise "custom_build_args has to be an String".red unless value.kind_of?String
+          @config.custom_build_args = value
         when :skip_alpha_removal
           @config.skip_alpha_removal = true
         when :clear_previous_screenshots


### PR DESCRIPTION
The custom_args directive in the Snapfile only allows to prepend the build command. However, from time to time it's necessary to actually pass additional parameters to the build tool. This pull request adds support for a custom_build_args directive that enables exactly this feature.
