### PR TITLE
fixes #69 Adding simple HTML/JS lightbox for images

### DIFF
--- a/lib/snapshot/page.html.erb
+++ b/lib/snapshot/page.html.erb
@@ -20,15 +20,50 @@
       .screenshot {
         cursor: pointer;
         border: 1px #EEE solid;
+        z-index: 0;
       }
       td {
         text-align: center;
+      }
+      #overlay {
+        position:fixed;
+        top:0;
+        left:0;
+        background:rgba(0,0,0,0.8);
+        z-index:5;
+        width:100%;
+        height:100%;
+        display:none;
+        cursor: zoom-out;
+        text-align: center;
+      }
+      #imageDisplay {
+        height: auto;
+        width: auto;
+        z-index: 10;
+        cursor: pointer;
+      }
+      #imageInfo {
+        background: none repeat scroll 0 0 rgba(0, 0, 0, 0.2);
+        border-radius: 5px;
+        color: white;
+        margin: 20px;
+        padding: 10px;
+        position: absolute;
+        right: 0;
+        top: 0;
+        width: 250px;
+        z-index: -1;
+      }
+      #imageInfo:hover {
+        z-index: 20;
       }
     </style>
   </head>
   <body>
     <% divide_size_by = 5.0 %>
     <% max_width = 180 %>
+    <% image_counter = 0 %>
 
 
     <% @data.each do |language, content| %>
@@ -49,11 +84,13 @@
                 <% width = ((screen_size[0] / divide_size_by).round rescue 0) %>
                 <% width = [width, max_width].min %>
                 <% style = (width > 0 ? "width: #{width}px;" : '') %>
-                <a href="<%= screen_path %>" target="_blank">
+                <% image_counter += 1 %>
+                <a href="<%= screen_path %>" target="_blank" class="screenshotLink">
                   <img class="screenshot"
                          src="<%= screen_path %>"
                        style="<%= style %>"
-                         alt="<%= language %> <%= device_name %>" />
+                         alt="<%= language %> <%= device_name %>"
+                data-counter="<%= image_counter %>" />
                 </a>
               </td>
             <% end %>
@@ -61,5 +98,80 @@
         <% end %>
       </table>
     <% end %>
+      <div id="overlay">
+        <img id="imageDisplay" src="" alt="" />
+        <div id="imageInfo"></div>
+      </div>
+      <script type="text/javascript">
+        var overlay        = document.getElementById('overlay');
+        var imageDisplay   = document.getElementById('imageDisplay');
+        var imageInfo      = document.getElementById('imageInfo');
+        var screenshotLink = document.getElementsByClassName('screenshotLink');
+        
+        for (index = 0; index < screenshotLink.length; ++index) {
+          screenshotLink[index].addEventListener('click', function(e) {
+            e.preventDefault();
+            
+            var img = e.target;
+            if (e.target.tagName == 'A') {
+              img = e.target.children[0];
+            }
+            
+            // beautify
+            var tmpImg = new Image();
+            tmpImg.src = img.src;
+            imageDisplay.style.height     = 'auto';
+            imageDisplay.style.width     = 'auto';
+            imageDisplay.style.paddingTop   = '0px';
+            if (window.innerHeight < tmpImg.height) {
+              imageDisplay.style.height = document.documentElement.clientHeight+'px';
+            } else if (window.innerWidth < tmpImg.width) {
+              imageDisplay.style.width = document.documentElement.clientWidth;+'px';
+            } else {
+              imageDisplay.style.paddingTop = parseInt((window.innerHeight - tmpImg.height) / 2)+'px';
+            }
+
+            imageDisplay.src             = img.src;
+            imageDisplay.alt             = img.alt;
+            imageDisplay.dataset.counter = img.dataset.counter;
+            
+            imageInfo.innerHTML          = '<h3>'+img.alt+'</h3>';
+            imageInfo.innerHTML         += img.src.split("/").pop();
+            imageInfo.innerHTML         += '<br />'+tmpImg.height+'&times;'+tmpImg.width+'px';
+                    
+            overlay.style.display        = "block";
+          });
+        }
+        
+        imageDisplay.addEventListener('click', function(e) {
+          e.stopPropagation(); // !
+          
+          overlay.style.display = "none";
+          
+          img_counter = parseInt(e.target.dataset.counter) + 1;
+          try {
+            link = document.body.querySelector('img[data-counter="'+img_counter+'"]').parentNode;
+          } catch (e) {
+            try {
+              link = document.body.querySelector('img[data-counter="0"]').parentNode;
+            } catch (e) {
+              return false;
+            }
+          }
+
+          if (document.createEvent) {
+            var evObj = document.createEvent('MouseEvents', true);
+            evObj.initMouseEvent("click", false, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+            link.dispatchEvent(evObj);
+          } else if (document.createEventObject) { //IE
+            var evObj = document.createEventObject();
+            link.fireEvent('onclick', evObj);
+          }
+        });
+
+        overlay.addEventListener('click', function(e) {
+          overlay.style.display = "none";
+        })
+      </script>
   </body>
 </html>


### PR DESCRIPTION
Old school JavaScript to **not** depend on external files or JS libraries. So this file can be run locally without external dependencies. 

Tested on the latest versions of 
- FF Win 7
- Chrome Win 7
- IE Win 7
- FF OS X
- Chrome OS X
- Safari OS X
