### PR TITLE
Proper shellescape escaping

### DIFF
--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -189,7 +189,7 @@ module Snapshot
         "-w '#{device}'",
         "-D '#{TRACE_DIR}/trace'",
         "-t 'Automation'",
-        "'#{@app_path.shellescape}'",
+        "#{@app_path.shellescape}",
         "-e UIARESULTSPATH '#{TRACE_DIR}'",
         "-e UIASCRIPT '#{script_path}'",
         "-AppleLanguages '(#{language})'",


### PR DESCRIPTION
Shellescape now properly escapes the `instruments` command argument when an application's product name contains quotes. #101 

I don't have any test units set up for this, I just tested manually.  May need more testing.
