### PR TITLE
fixes #44 Support apps with WatchKit

### DIFF
--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -9,8 +9,13 @@ module Snapshot
       SnapshotConfig.shared_instance.js_file # to verify the file can be found earlier
 
       Builder.new.build_app(clean: clean)
-      @app_path = "/tmp/snapshot/build/#{SnapshotConfig.shared_instance.app_name}"
-
+      
+      if SnapshotConfig.shared_instance.app_name
+        @app_path = "/tmp/snapshot/build/#{SnapshotConfig.shared_instance.app_name}"
+      else
+        @app_path = Dir.glob("/tmp/snapshot/build/*.app").first
+      end
+      
       counter = 0
       errors = []
 

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -9,7 +9,7 @@ module Snapshot
       SnapshotConfig.shared_instance.js_file # to verify the file can be found earlier
 
       Builder.new.build_app(clean: clean)
-      @app_path = Dir.glob("/tmp/snapshot/build/*.app").first
+      @app_path = "/tmp/snapshot/build/#{SnapshotConfig.shared_instance.app_name}"
 
       counter = 0
       errors = []

--- a/lib/snapshot/snapshot_config.rb
+++ b/lib/snapshot/snapshot_config.rb
@@ -22,9 +22,6 @@ module Snapshot
     # @return (String) The path to the JavaScript file to use
     attr_accessor :manual_js_file
 
-    # @return (String) The name of the build product, manually set by the user using the config file
-    attr_accessor :manual_app_name
-
     # @return (String) The path, in which the screenshots should be stored
     attr_accessor :screenshots_path
 
@@ -145,23 +142,20 @@ module Snapshot
 
     # Returns the file name of the build product
     def app_name
-      result = manual_app_name;
 
-      unless result
-        project_key = 'project'
-        project_key = 'workspace' if project_path.end_with?'.xcworkspace'
-        command = "xcodebuild -#{project_key} '#{project_path}' -showBuildSettings | grep 'WRAPPER_NAME' | sed 's/[ ]*WRAPPER_NAME = //'"
-        Helper.log.debug command
+      project_key = 'project'
+      project_key = 'workspace' if project_path.end_with?'.xcworkspace'
+      command = "xcodebuild -#{project_key} '#{project_path}' -showBuildSettings | grep 'WRAPPER_NAME' | sed 's/[ ]*WRAPPER_NAME = //'"
+      Helper.log.debug command
         
-        result = `#{command}`.strip!
+      result = `#{command}`.strip!
+      
+      if result
         Helper.log.debug "Found app name: #{result}"
+        return result
       end
 
-      unless result
-        raise "Could not determine which app name to use.".red
-      end
-
-      return result
+      return nil
     end
 
     # The JavaScript UIAutomation file

--- a/lib/snapshot/snapshot_config.rb
+++ b/lib/snapshot/snapshot_config.rb
@@ -22,6 +22,9 @@ module Snapshot
     # @return (String) The path to the JavaScript file to use
     attr_accessor :manual_js_file
 
+    # @return (String) The name of the build product, manually set by the user using the config file
+    attr_accessor :manual_app_name
+
     # @return (String) The path, in which the screenshots should be stored
     attr_accessor :screenshots_path
 
@@ -138,6 +141,27 @@ module Snapshot
     # Returns the file name of the project
     def project_name
       File.basename(self.project_path, ".*" )
+    end
+
+    # Returns the file name of the build product
+    def app_name
+      result = manual_app_name;
+
+      unless result
+        project_key = 'project'
+        project_key = 'workspace' if project_path.end_with?'.xcworkspace'
+        command = "xcodebuild -#{project_key} '#{project_path}' -showBuildSettings | grep 'FULL_PRODUCT_NAME' | sed 's/[ ]*FULL_PRODUCT_NAME = //'"
+        Helper.log.debug command
+        
+        result = `#{command}`.strip!
+        Helper.log.debug "Found app name: #{result}"
+      end
+
+      unless result
+        raise "Could not determine which app name to use.".red
+      end
+
+      return result
     end
 
     # The JavaScript UIAutomation file

--- a/lib/snapshot/snapshot_config.rb
+++ b/lib/snapshot/snapshot_config.rb
@@ -150,7 +150,7 @@ module Snapshot
       unless result
         project_key = 'project'
         project_key = 'workspace' if project_path.end_with?'.xcworkspace'
-        command = "xcodebuild -#{project_key} '#{project_path}' -showBuildSettings | grep 'FULL_PRODUCT_NAME' | sed 's/[ ]*FULL_PRODUCT_NAME = //'"
+        command = "xcodebuild -#{project_key} '#{project_path}' -showBuildSettings | grep 'WRAPPER_NAME' | sed 's/[ ]*WRAPPER_NAME = //'"
         Helper.log.debug command
         
         result = `#{command}`.strip!


### PR DESCRIPTION
Projects that support WatchKit generates three build products (the iOS app, the Watch app and the WatchKit Extension) instead of normally just one.

This fix will get the iOS app product name from the build settings (PRODUCT_NAME) in the Xcode project and use that to find the right product to pass to Instruments. Added a way to set this manually in config, if needed.
