### PR TITLE
Align device names to the left so they remain visible with many screenshots

### DIFF
--- a/lib/snapshot/page.html.erb
+++ b/lib/snapshot/page.html.erb
@@ -22,6 +22,9 @@
         border: 1px #EEE solid;
         z-index: 0;
       }
+      th {
+        text-align: left;
+      }
       td {
         text-align: center;
       }


### PR DESCRIPTION
I am generating around 50 screenshots so the device name was off the screen.
