### PR TITLE
Custom build options

### DIFF
--- a/bin/snapshot
+++ b/bin/snapshot
@@ -22,6 +22,7 @@ class SnapshotApplication
     program :help_formatter, :compact
 
     global_option '--snapfile PATH', String, 'Custom path for your Snapfile.'
+    global_option '--nobuild', 'Skips the build process when running snapshot.'
     global_option '--noclean', 'Skips the clean process of the build command when running snapshot.'
     global_option('--verbose', 'Shows all output printed by Instruments.') { $verbose = true }
 
@@ -36,7 +37,7 @@ class SnapshotApplication
         Dir.chdir(path) do # switch the context
           Snapshot::DependencyChecker.check_simulators
           Snapshot::SnapshotConfig.shared_instance(options.snapfile)
-          Snapshot::Runner.new.work(clean: !options.noclean)
+          Snapshot::Runner.new.work(clean: !options.noclean, build: !options.nobuild)
         end
       end
     end

--- a/lib/snapshot/builder.rb
+++ b/lib/snapshot/builder.rb
@@ -1,14 +1,12 @@
 module Snapshot
   class Builder
-    BUILD_DIR = '/tmp/snapshot'
-
 
     def initialize
-      
+      @build_dir = SnapshotConfig.shared_instance.build_dir || '/tmp/snapshot'
     end
 
     def build_app(clean: true)
-      FileUtils.rm_rf(BUILD_DIR) if clean
+      FileUtils.rm_rf(@build_dir) if clean
 
       command = SnapshotConfig.shared_instance.build_command
 
@@ -70,12 +68,12 @@ module Snapshot
         [
           build_command,
           "-sdk iphonesimulator",
-          "CONFIGURATION_BUILD_DIR='#{BUILD_DIR}/build'",
+          "CONFIGURATION_BUILD_DIR='#{@build_dir}/build'",
           "-#{proj_key} '#{proj_path}'",
           "-scheme '#{scheme}'",
-          "DSTROOT='#{BUILD_DIR}'",
-          "OBJROOT='#{BUILD_DIR}'",
-          "SYMROOT='#{BUILD_DIR}'",
+          "DSTROOT='#{@build_dir}'",
+          "OBJROOT='#{@build_dir}'",
+          "SYMROOT='#{@build_dir}'",
           custom_build_args,
           actions.join(' ')
         ].join(' ')

--- a/lib/snapshot/builder.rb
+++ b/lib/snapshot/builder.rb
@@ -31,14 +31,17 @@ module Snapshot
             raise ex
           end
         end
+        Process.wait(pid)
       end
+      # Exit status for build command, should be 0 if build succeeded
+      cmdstatus = $?.exitstatus
 
-      if all_lines.join('\n').include?'** BUILD SUCCEEDED **'
+      if cmdstatus == 0 || all_lines.join('\n').include?('** BUILD SUCCEEDED **')
         Helper.log.info "BUILD SUCCEEDED".green
         return true
       else
         Helper.log.info(all_lines.join(' '))
-        raise "Looks like the build was not successfull."
+        raise "Looks like the build was not successful."
       end
     end
 

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -153,7 +153,8 @@ module Snapshot
 
     def determine_app_path
       # Determine the path to the actual app and not the WatchKit app
-      Dir.glob("/tmp/snapshot/build/*.app/*.plist").each do |path|
+      build_dir = SnapshotConfig.shared_instance.build_dir || '/tmp/snapshot'
+      Dir.glob("#{build_dir}/**/*.app/*.plist").each do |path|
         watchkit_enabled = `/usr/libexec/PlistBuddy -c 'Print WKWatchKitApp' '#{path}'`.strip
         next if watchkit_enabled == 'true' # we don't care about WatchKit Apps
 

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -5,10 +5,10 @@ module Snapshot
   class Runner
     TRACE_DIR = '/tmp/snapshot_traces'
 
-    def work(clean: true)
+    def work(clean: true, build: true)
       SnapshotConfig.shared_instance.js_file # to verify the file can be found earlier
 
-      Builder.new.build_app(clean: clean)
+      Builder.new.build_app(clean: clean) if build
       @app_path = determine_app_path
 
       counter = 0

--- a/lib/snapshot/snapshot_config.rb
+++ b/lib/snapshot/snapshot_config.rb
@@ -25,8 +25,11 @@ module Snapshot
     # @return (String) The path, in which the screenshots should be stored
     attr_accessor :screenshots_path
 
-    # @return (String) The build command, wich should build the app to '/tmp/snapshot'
+    # @return (String) The build command, wich should build the app to build_dir (/tmp/snapshot by default)
     attr_accessor :build_command
+
+    # @return (String) The build directory, defaults to '/tmp/snapshot'
+    attr_accessor :build_dir
 
     # @return (BOOL) Skip the removal of the alpha channel from the screenshots
     attr_accessor :skip_alpha_removal

--- a/lib/snapshot/snapshot_config.rb
+++ b/lib/snapshot/snapshot_config.rb
@@ -141,7 +141,7 @@ module Snapshot
 
     # Returns the file name of the project
     def project_name
-      File.basename(self.project_path, ".*" )
+      File.basename(self.project_path, ".*" ) if self.project_path
     end
 
     # The JavaScript UIAutomation file

--- a/lib/snapshot/snapshot_file.rb
+++ b/lib/snapshot/snapshot_file.rb
@@ -44,6 +44,9 @@ module Snapshot
         when :build_command
           raise "build_command has to be an String".red unless value.kind_of?String
           @config.build_command = value
+        when :build_dir
+          raise "build_dir has to be an String".red unless value.kind_of?String
+          @config.build_dir = File.expand_path(value)
         when :custom_args
           raise "custom_args has to be an String".red unless value.kind_of?String
           @config.custom_args = value


### PR DESCRIPTION
This PR adds a few extra options:
- Ability to skip building completely (`--nobuild` parameter)
- Configure build directory (`build_dir` config variable)
- Allow running on apps that don't use Xcode project files (e.g. RubyMotion)

Not sure if allowing other build systems is something you want in this project, I'd understand if you prefer to keep it simple.
