### PR TITLE
Update README.md for issue #114

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,12 +233,13 @@ ios_version "9.0"
 
 ### Custom Args for the build command
 Use the ```custom_args``` directive to prepend custom statements to the build command.
-```ruby
-custom_args "GCC_PREPROCESSOR_DEFINITIONS='SCREENSHOTS'"
-```
+
 Add a ```custom_build_args``` line to your ```Snapfile``` to add custom arguments to the build command.
+
+Here is an example for adding a preprocessor macro `SNAPSHOT` and  a custom build setting `SNAPSHOT_ENABLE`.
+
 ```ruby
-custom_build_args "-configuration release"
+custom_build_args "GCC_PREPROCESSOR_DEFINITIONS='$(inherited) SNAPSHOT=1' SNAPSHOT_ENABLE = YES"
 ```
 
 ### Custom Build Command


### PR DESCRIPTION
I've updated the readme for issue #114.

`GCC_PREPROCESSOR_DEFINITIONS` should be in `custom_build_args` and not in `custom_args`.

I wrote an example for `custom_build_args` adding both a preprocessor macro and a custom build setting. Note that I have also added `$(inherited)` to avoid to erase the existing preprocessor macros.

I have deleted the code example for `custom_args`, I don't know what I could write for an example for this key.

I have tested the `custom_build_args` setting presented in this example in my own project using `xcodebuild` with success.
