### PR TITLE
Ability to pass the regional format in addition of the language (issues #4 and #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,17 +191,8 @@ devices([
 languages([
   "en-US",
   "de-DE",
-  "es-ES"
-])
-```
-
-If you want to use a specific locale, you can also use 
-
-```ruby
-languages([
-  "en-US",
-  "de-DE",
-  ["cmn-Hans", "cmn-Hans_CN"]
+  "es-ES",
+  ["cmn-Hans", "cmn-Hans_CN"] # you can specify a locale if needed
 ])
 ```
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,16 @@ languages([
 ])
 ```
 
+If you want to use a specific locale, you can also use 
+
+```ruby
+languages([
+  "en-US",
+  "de-DE",
+  ["cmn-Hans", "cmn-Hans_CN"]
+])
+```
+
 ### JavaScript file
 Usually ```snapshot``` automatically finds your JavaScript file. If that's not the case, you can pass the path 
 to your test file.

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -19,7 +19,7 @@ module Snapshot
       SnapshotConfig.shared_instance.devices.each do |device|
         SnapshotConfig.shared_instance.languages.each do |language_item|
 
-          if language_item.instance_of? String
+          if language_item.instance_of?String
             language = language_item
             locale = language_item
           else

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -17,13 +17,21 @@ module Snapshot
       FileUtils.rm_rf SnapshotConfig.shared_instance.screenshots_path if SnapshotConfig.shared_instance.clear_previous_screenshots
 
       SnapshotConfig.shared_instance.devices.each do |device|
-        SnapshotConfig.shared_instance.languages.each do |language|
-          reinstall_app(device, language) unless ENV["SNAPSHOT_SKIP_UNINSTALL"]
+        SnapshotConfig.shared_instance.languages.each do |language_item|
+
+          if language_item.instance_of? String
+            language = language_item
+            locale = language_item
+          else
+            (language, locale) = language_item            
+          end
+
+          reinstall_app(device, language, locale) unless ENV["SNAPSHOT_SKIP_UNINSTALL"]
 
           prepare_simulator(device, language)
           
           begin
-            errors.concat(run_tests(device, language))
+            errors.concat(run_tests(device, language, locale))
             counter += copy_screenshots(language)
           rescue => ex
             Helper.log.error(ex)
@@ -72,7 +80,7 @@ module Snapshot
       raise "Could not find simulator '#{name}' to install the app on."
     end
 
-    def reinstall_app(device, language)
+    def reinstall_app(device, language, locale)
 
       app_identifier = ENV["SNAPSHOT_APP_IDENTIFIER"]
       app_identifier ||= @app_identifier
@@ -95,13 +103,13 @@ module Snapshot
       com("xcrun simctl shutdown booted")
     end
 
-    def run_tests(device, language)
-      Helper.log.info "Running tests on #{device} in language #{language}".green
-
+    def run_tests(device, language, locale)
+      Helper.log.info "Running tests on #{device} in language #{language} (locale #{locale})".green
+      
       clean_old_traces
 
       ENV['SNAPSHOT_LANGUAGE'] = language
-      command = generate_test_command(device, language)
+      command = generate_test_command(device, language, locale)
       Helper.log.debug command.yellow
       
       retry_run = false
@@ -145,7 +153,7 @@ module Snapshot
       if retry_run
         Helper.log.error "Instruments tool failed again. Re-trying..."
         sleep 2 # We need enough sleep... that's an instruments bug
-        errors = run_tests(device, language)
+        errors = run_tests(device, language, locale)
       end
 
       return errors
@@ -200,7 +208,7 @@ module Snapshot
       return Dir.glob("#{TRACE_DIR}/**/*.png").count
     end
 
-    def generate_test_command(device, language)
+    def generate_test_command(device, language, locale)
       is_ipad = (device.downcase.include?'ipad')
       script_path = SnapshotConfig.shared_instance.js_file(is_ipad)
       custom_run_args = SnapshotConfig.shared_instance.custom_run_args || ENV["SNAPSHOT_CUSTOM_RUN_ARGS"] || ''
@@ -214,7 +222,7 @@ module Snapshot
         "-e UIARESULTSPATH '#{TRACE_DIR}'",
         "-e UIASCRIPT '#{script_path}'",
         "-AppleLanguages '(#{language})'",
-        "-AppleLocale '#{language}'",
+        "-AppleLocale '#{locale}'",
         custom_run_args,
       ].join(' ')
     end


### PR DESCRIPTION
It can be very useful for some languages like Chinese.
As mentioned in issues #4 and #62, sometimes the language alone isn't sufficient.

Simplified Chinese (cmn-Hans) is used both in China and Hong-Kong for example.
If you pass `AppleLanguages (cmn-Hans)` and `AppleLocale cmn-Hans`, and call

```
[[NSLocale currentLocale] objectForKey:NSLocaleCurrencySymbol]
```

the result is undefined, you get `¤`
Using `cmn-Hans_CN` for `AppleLocale`, you get the Yuan symbol `￥` and for `cmn-Hans_HK`, you get the dollar symbol `$`.

I added the ability to specify a [language, locale] pair in the languages list of the Snapfile.
