### PR TITLE
Add `test` action, for when you only want to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ To skip cleaning the project:
 snapshot --noclean
 ```
 
+To only run tests (i.e. don't actually take any screenshots):
+```
+snapshot test
+```
+
+
 By default, `snapshot`, will re-install the app, to make sure it's in a clean state. In case you don't want this run
 
 ```

--- a/bin/snapshot
+++ b/bin/snapshot
@@ -42,6 +42,20 @@ class SnapshotApplication
       end
     end
 
+    command :test do |c|
+      c.syntax = 'snapshot test'
+      c.description = 'Runs the automated tests.'
+
+      c.action do |args, options|
+        path = (Snapshot::Helper.fastlane_enabled?? './fastlane' : '.')
+        Dir.chdir(path) do # switch the context
+          Snapshot::DependencyChecker.check_simulators
+          Snapshot::SnapshotConfig.shared_instance(options.snapfile)
+          Snapshot::Runner.new.work(clean: !options.noclean, build: !options.nobuild, take_snapshots: false)
+        end
+      end
+    end
+
     command :init do |c|
       c.syntax = 'snapshot init'
       c.description = "Creates a new Snapfile in the current directory"

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -14,7 +14,7 @@ module Snapshot
       counter = 0
       errors = []
 
-      FileUtils.rm_rf SnapshotConfig.shared_instance.screenshots_path if SnapshotConfig.shared_instance.clear_previous_screenshots and take_snapshots
+      FileUtils.rm_rf SnapshotConfig.shared_instance.screenshots_path if (SnapshotConfig.shared_instance.clear_previous_screenshots and take_snapshots)
 
       SnapshotConfig.shared_instance.devices.each do |device|
         SnapshotConfig.shared_instance.languages.each do |language|


### PR DESCRIPTION
OK so this is what I've been using for the last few days for just running `UIAutomation` tests, without doing all the screenshot stuff. I'm happy with the way it works but I'm not particularly happy with the way I've implemented it; adding a boolean feels like a hack. But I'm keen to get some feedback on how you'd prefer it implemented and I can refactor it. Also adds test pass/failure status so we get pretty output like this

![](https://dl.dropbox.com/u/17966172/screenshots/STOPEMGS-2015.04.20-16-53-58.png)
