### PR TITLE
Added option for breaking flow at first error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ snapshot test
 ```
 
 
+If any error occurs while running the snapshot script on a device, that device will not have any screenshots, and `snapshot` will continue with the next device or language. To stop the flow after the first error, run
+
+```
+SNAPSHOT_BREAK_ON_FIRST_ERROR=1 snapshot
+```
+
+
 By default, `snapshot`, will re-install the app, to make sure it's in a clean state. In case you don't want this run
 
 ```

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -38,7 +38,11 @@ module Snapshot
           end
 
           teardown_simulator(device, language)
+
+          break if errors.any? && ENV["SNAPSHOT_BREAK_ON_FIRST_ERROR"]
         end
+
+        break if errors.any? && ENV["SNAPSHOT_BREAK_ON_FIRST_ERROR"]
       end
 
       `killall "iOS Simulator"` # close the simulator after the script is finished


### PR DESCRIPTION
Currently, the scripts logs the error and continues with the next device/language combination.

By running `SNAPSHOT_BREAK_ON_FIRST_ERROR=1 snapshot`, it will now stop at the first error.
