### PR TITLE
Fixing keyboard navigation

### DIFF
--- a/lib/snapshot/page.html.erb
+++ b/lib/snapshot/page.html.erb
@@ -176,7 +176,7 @@
           overlay.style.display = "none";
         })
         
-      document.onkeypress = function(e) {
+      function keyPressed(e) {
         e = e || window.event;
         var charCode = e.keyCode || e.which;
         switch(charCode) {
@@ -196,9 +196,11 @@
           case 100:
             e.preventDefault();
             document.getElementById('imageDisplay').dataset.counter -= 2; // hacky
+            doClick(imageDisplay);
             break;
          }
       };
+      document.body.addEventListener('keydown', keyPressed);
       </script>
   </body>
 </html>


### PR DESCRIPTION
`onkeypress` event is not suported by Chrome, see http://help.dottoro.com/ljlwfxum.php switching to `keydown`.

fixes #99
