### PR TITLE
[WIP] Upgrade to UI Tests

### DIFF
--- a/lib/snapshot/collector.rb
+++ b/lib/snapshot/collector.rb
@@ -41,11 +41,11 @@ module Snapshot
 
       activities = []
       report["TestableSummaries"].each do |summary|
-        summary["Tests"].each do |test|
-          test["Subtests"].each do |subtest|
-            subtest["Subtests"].each do |subtest2|
-              subtest2["Subtests"].each do |subtest3|
-                subtest3["ActivitySummaries"].each do |activity|
+        (summary["Tests"] || []).each do |test|
+          (test["Subtests"] || []).each do |subtest|
+            (subtest["Subtests"] || []).each do |subtest2|
+              (subtest2["Subtests"] || []).each do |subtest3|
+                (subtest3["ActivitySummaries"] || []).each do |activity|
                   # We now check if it's the drag gesture with a negative value
                   was_snapshot = activity["Title"].match(/Press and drag from Target Application.*\[32.10.*\].*/)
                   activities << activity if was_snapshot


### PR DESCRIPTION
Work in progress

From the README:

> Apple announced a new version of Xcode with support for UI Tests built in right into Xcode. This technology allows snapshot to be even better: Instead of dealing with UI Automation Javascript code, you will be able to write the screenshot code in Swift or Objective C allowing you to use debugging features like breakpoints.
> 
> It's still work in progress and there are some technical difficulties I need to solve.
> 
> As a result, snapshot will be completely rewritten from ground up without changing its public API :rocket:
