### PR TITLE
Beefing up the app_path determination

### DIFF
--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -185,10 +185,16 @@ module Snapshot
         next if watchkit_enabled == 'true' # we don't care about WatchKit Apps
 
         app_identifier = `/usr/libexec/PlistBuddy -c 'Print CFBundleIdentifier' '#{path}' 2>&1`.strip
-        if app_identifier and app_identifier.length > 0
-          # This seems to be the valid Info.plist
-          @app_identifier = app_identifier
-          return File.expand_path("..", path) # the app
+        if app_identifier and app_identifier.length > 0 and !app_identifier.include? "Does Not Exist"
+          wanted_identifier = ENV["SNAPSHOT_APP_IDENTIFIER"]
+          if wanted_identifier != nil and wanted_identifier == app_identifier
+            @app_identifier = wanted_identifier
+            return File.expand_path("..", path) # the app
+          else if wanted_identifier == nil
+          	# This seems to be the valid Info.plist
+            @app_identifier = app_identifier
+            return File.expand_path("..", path) # the app
+          end
         end
       end
 


### PR DESCRIPTION
When using multiple .plists in your application snapshot could inadvertly select an app path that is not correct. 

One example of this is when you use the new Google-Services.plist combined with an Apple Watch App. In this scenario the determine_app_path would first check Google-Services.plist, which would return false to the watch check, and then true for the CFBundleIdentifier test because it just check for length of the output.

The new code checks that the output also does not contain "Does Not Exist" as well as respect the app_identifier environment variable.
