### PR TITLE
Fix Snapshot detection of simulators in Xcode 7

### DIFF
--- a/lib/snapshot/latest_ios_version.rb
+++ b/lib/snapshot/latest_ios_version.rb
@@ -1,13 +1,15 @@
 module Snapshot
   class LatestIosVersion
+    @@version = nil
     def self.version
       return ENV["SNAPSHOT_IOS_VERSION"] if ENV["SNAPSHOT_IOS_VERSION"]
+      return @@version if @@version
 
       output = `xcodebuild -version -sdk`.split("Mac").last # don't care about the Mac Part
       matched = output.match(/iPhoneSimulator([\d\.]+)\.sdk/)
       
       if matched.length > 1
-        return matched[1]
+        return @@version ||= matched[1]
       else
         raise "Could not determine installed iOS SDK version. Please pass it via the environment variable 'SNAPSHOT_IOS_VERSION'".red
       end

--- a/lib/snapshot/simulators.rb
+++ b/lib/snapshot/simulators.rb
@@ -22,10 +22,15 @@ module Snapshot
 
       output.split("\n").each do |current|
         # Example: "iPhone 5 (8.1 Simulator) [C49ECC4A-5A3D-44B6-B9BF-4E25BC326400]"
+        # Example: "iPhone 6 (9.0) [072E4EA2-861F-44CD-AB77-FB1FE07E541C]"
+        
+        match = current.match /((.+?) \(.+?\)) \[.+?\]/
+        next if match.nil?
+        
         if name_only
-          result << current.split(' (').first if current.include?"Simulator"
+          result << match[2]
         else
-          result << current.split(' [').first if current.include?"Simulator"
+          result << match[1]
         end
       end
 

--- a/lib/snapshot/snapshot_config.rb
+++ b/lib/snapshot/snapshot_config.rb
@@ -115,10 +115,10 @@ module Snapshot
     # This has to be done after parsing the Snapfile (iOS version)
     def set_default_simulators
       self.devices ||= [
-        "iPhone 6 (#{self.ios_version} Simulator)",
-        "iPhone 6 Plus (#{self.ios_version} Simulator)",
-        "iPhone 5 (#{self.ios_version} Simulator)",
-        "iPhone 4s (#{self.ios_version} Simulator)"
+        "iPhone 6" + version_suffix(self.ios_version),
+        "iPhone 6 Plus" + version_suffix(self.ios_version),
+        "iPhone 5" + version_suffix(self.ios_version),
+        "iPhone 4s" + version_suffix(self.ios_version),
       ]
     end
 
@@ -128,12 +128,12 @@ module Snapshot
 
       actual_devices = []
       self.devices.each do |current|
-        current += " (#{self.ios_version} Simulator)" unless current.include?"Simulator"
+        current += version_suffix(self.ios_version) unless current.include? " ("
 
-        unless Simulators.available_devices.include?current
-          raise "Device '#{current}' not found. Available device types: #{Simulators.available_devices}".red
-        else
+        if Simulators.available_devices.include? current
           actual_devices << current
+        else
+          raise "Device '#{current}' not found. Available device types: #{Simulators.available_devices}".red
         end
       end
       self.devices = actual_devices
@@ -217,6 +217,16 @@ module Snapshot
         end
       rescue => ex
         raise "Could not fetch available schemes: #{ex}".red
+      end
+    end
+
+    def version_suffix version
+      # Xcode 6 and before: "iPhone 5 (8.0 Simulator)"
+      # Xcode 7 and later: "iPhone 6 (9.0)"
+      if LatestIosVersion.version.to_i >= 9
+        " (#{version})"
+      else
+        " (#{version} Simulator)"
       end
     end
   end


### PR DESCRIPTION
Xcode 7 changed the way simulators are named — `instruments -s` now say "iPhone 6 (9.0)", not "... (9.0 Simulator", which broke the detection of available simulators, dependency check and the configuration defaults… This fixes it.
