### PR TITLE
A few fixes to app reinstalation

### DIFF
--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -109,11 +109,12 @@ module Snapshot
       udid = udid_for_simulator(device)
 
       com("killall 'iOS Simulator'")
+      com("killall 'Simulator'")
       sleep 3
       com("xcrun simctl boot '#{udid}'")
-      com("xcrun simctl uninstall booted '#{app_identifier}'")
+      com("xcrun simctl uninstall '#{udid}' '#{app_identifier}'")
       sleep 3
-      com("xcrun simctl install booted '#{@app_path.shellescape}'")
+      com("xcrun simctl install '#{udid}' #{@app_path.shellescape}")
       com("xcrun simctl shutdown booted")
     end
 


### PR DESCRIPTION
- Kill “Simulator” (Xcode 7 renamed iOS Simulator)
- shellescape and quotes shouldn’t be used together — if you have spaces in the path (e.g. in the Xcode configuration name or build product name), it won’t work — shellescape escapes spaces with a backslash, but they're treated literally inside quotes
- refer to the sims via their UDIDs. Probably doesn’t matter, but seems more reliable…
