### PR TITLE
Removed top padding from image preview

### DIFF
--- a/lib/snapshot/page.html.erb
+++ b/lib/snapshot/page.html.erb
@@ -134,7 +134,6 @@
             tmpImg.src = img.src;
             imageDisplay.style.height     = 'auto';
             imageDisplay.style.width     = 'auto';
-            imageDisplay.style.paddingTop   = '20px';
             if (window.innerHeight < tmpImg.height) {
               imageDisplay.style.height = document.documentElement.clientHeight+'px';
             } else if (window.innerWidth < tmpImg.width) {


### PR DESCRIPTION
Top padding of 20px in HTML preview caused to have another 20px at the bottom of screenshot invisible, in case image height is larger, than the screen height, in other cases - this padding seems to do nothing.
