### PR TITLE
Added fix to uninstall and reinstall the app between runs on Xcode 7

### DIFF
--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -112,13 +112,17 @@ module Snapshot
       udid = udid_for_simulator(device)
 
       kill_simulator
-      sleep 3
-      com("xcrun simctl boot '#{udid}'")
 
-      com("xcrun simctl uninstall '#{udid}' '#{app_identifier}'") unless Snapshot.min_xcode7?
-      sleep 3
-      com("xcrun simctl install '#{udid}' #{@app_path.shellescape}") unless Snapshot.min_xcode7?
-      com("xcrun simctl shutdown booted")
+      if Snapshot.min_xcode7?
+        clean_old_traces
+        com("xcrun instruments -w '#{udid}' -t 'Blank' -l 1 -D '#{TRACE_DIR}/trace'")
+      else
+        com("xcrun simctl boot '#{udid}'")
+      end
+
+      com("xcrun simctl uninstall booted '#{app_identifier}'")
+      com("xcrun simctl install booted #{@app_path.shellescape}")
+      com("xcrun simctl shutdown booted") unless Snapshot.min_xcode7?
     end
 
     def run_tests(device, language, locale)

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -230,6 +230,7 @@ module Snapshot
     end
 
     def kill_simulator
+      `xcrun simctl shutdown booted`
       `killall "iOS Simulator"`
       `killall "Simulator"`
     end


### PR DESCRIPTION
Fixes #193.

In Xcode 7, the `uninstall` and `install` commands only work when `backboardd` is running. To solve this, it launches the full simulator instead of using `xcrun simctl boot` when using Xcode 7.

I know you're working on a new version but until thats released, I figured it would be nice to get this fix out there.

**Edit**
There appears to be a timing issue that randomly occurs where the simulator hasn't fully shutdown before instruments is run again. I'm investigating.

**Edit**
Fixed.
