### PR TITLE
Install Xcode command line first before snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ I've been using many other solutions out there. Unfortunately none of them were 
 
 # Installation
 
+Make sure, you have the latest version of the Xcode command line tools installed:
+
+    xcode-select --install
+
 Install the gem
 
     sudo gem install snapshot
 
-Make sure, you have the latest version of the Xcode command line tools installed:
-
-    xcode-select --install
-    
 # UI Automation
 
 ## Getting started


### PR DESCRIPTION
As Xcode command line tools are required to be installed, this command should be executed first, otherwise gem install snapshot will result in an error.
