### PR TITLE
Fixed "How does it work?" link (hash missing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Here a few links to get started:
 - [A first look into UI Tests](http://www.mokacoding.com/blog/xcode-7-ui-testing/)
 - [UI Testing in Xcode 7](http://masilotti.com/ui-testing-xcode-7/)
 
-**Note**: Since there is no official way to trigger a screenshot from UI Tests, `snapshot` uses a workaround (described in [How Does It Work?](how-does-it-work)) to trigger a screenshot. If you feel like this should be done right, please duplicate radar [23062925](https://openradar.appspot.com/radar?id=5056366381105152).
+**Note**: Since there is no official way to trigger a screenshot from UI Tests, `snapshot` uses a workaround (described in [How Does It Work?](#how-does-it-work)) to trigger a screenshot. If you feel like this should be done right, please duplicate radar [23062925](https://openradar.appspot.com/radar?id=5056366381105152).
 
 # Quick Start
 


### PR DESCRIPTION
Just a small fix, I hope you don't bother merging a pull request for that.
