### PR TITLE
Check for case where matched is nil.

### DIFF
--- a/lib/snapshot/latest_ios_version.rb
+++ b/lib/snapshot/latest_ios_version.rb
@@ -13,7 +13,9 @@ module Snapshot
       end
 
       matched = output.match(/iOS ([\d\.]+) \(.*/)
-      if matched.length > 1
+      if matched.nil?
+        raise "Could not determine installed iOS SDK version. Try running the _xcodebuild_ command manually to ensure it works."
+      elsif matched.length > 1
         return @version ||= matched[1]
       else
         raise "Could not determine installed iOS SDK version. Please pass it via the environment variable 'SNAPSHOT_IOS_VERSION'".red


### PR DESCRIPTION
the value for `matched` can be nil in the case where the user has updated their version of Xcode but has not yet opened the GUI to agree to the license agreement.
