### PR TITLE
Added locale and uitesting flag to launch arguments

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -18,7 +18,7 @@ func setLanguage(app: XCUIApplication)
     do {
         let locale = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
         deviceLanguage = locale
-        app.launchArguments = ["-AppleLanguages", "(\(locale))"]
+        app.launchArguments = ["-AppleLanguages", "(\(locale))","-AppleLocale", "\"\(locale)\"","-ui_testing"]
     } catch {
         print("Couldn't detect/set language...")
     }


### PR DESCRIPTION
Added the locale so that the app should alway launch with the right formatter settings and a flag that gives the app the context of being tested, great for injecting test data.
