### PR TITLE
Provide interface for Objective C

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -48,3 +48,16 @@ func waitForLoadingIndicatorToDisappear()
         print("Number of Elements in Status Bar: \(query.count)... waiting for status bar to disappear")
     }
 }
+
+@objc class Snapshot: NSObject
+{
+    class func doSetLanguage(app: XCUIApplication)
+    {
+         setLanguage(app)
+    }
+    
+    class func doSnapshot(name: String, waitForLoadingIndicator: Bool = true)
+    {
+        snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator)
+    }
+}


### PR DESCRIPTION
As far as I can see, objective C can only access swift classes, so this
adds a class which can be bridged into ObjC and called with [Snapshot
doSetLanguage:]
Ideally, I’d keep the same method names [Snapshot setLanguage:] - but I
can’t figure out how to call a global function from a method of the
same name.
