### PR TITLE
Strip the region out when passing the language code to -AppleLanguages

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ I've been using many other solutions out there. Unfortunately none of them were 
 
 # Installation
 
+Make sure, you have the latest version of the Xcode command line tools installed:
+
+    xcode-select --install
+
 Install the gem
 
     sudo gem install snapshot
 
-Make sure, you have the latest version of the Xcode command line tools installed:
-
-    xcode-select --install
-    
 # UI Automation
 
 ## Getting started


### PR DESCRIPTION
`-AppleLanguages` is intended to just have either the two letter language code or the name of the language. For example `(en)`. At the moment the full lang_locale is being passed in (for example: `(en_US)`). This works in most cases but services & APIs relying on recognising a 2 letter code will fail.
