### PR TITLE
Ensure simulator matches requested iOS version

### DIFF
--- a/lib/snapshot/test_command_generator.rb
+++ b/lib/snapshot/test_command_generator.rb
@@ -70,7 +70,7 @@ module Snapshot
 
         device_udid = nil
         FastlaneCore::Simulator.all.each do |sim|
-          device_udid = sim.udid if sim.name.strip == device.strip and sim.ios_version.strip == Snapshot.config[:ios_version]
+          device_udid = sim.udid if sim.name.strip == device.strip and sim.ios_version == Snapshot.config[:ios_version]
         end
 
         value = "platform=iOS Simulator,id=#{device_udid},OS=#{Snapshot.config[:ios_version]}"

--- a/lib/snapshot/test_command_generator.rb
+++ b/lib/snapshot/test_command_generator.rb
@@ -70,7 +70,7 @@ module Snapshot
 
         device_udid = nil
         FastlaneCore::Simulator.all.each do |sim|
-          device_udid = sim.udid if sim.name.strip == device.strip
+          device_udid = sim.udid if sim.name.strip == device.strip and sim.ios_version.strip == Snapshot.config[:ios_version]
         end
 
         value = "platform=iOS Simulator,id=#{device_udid},OS=#{Snapshot.config[:ios_version]}"


### PR DESCRIPTION
snapshot was choosing the last simulator to match the provided name and ignoring the requested iOS version
