### PR TITLE
Network activity indicator view in the status bar gets recognized properly

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -55,11 +55,13 @@ func snapshot(name: String, waitForLoadingIndicator: Bool = true)
     
     class func waitForLoadingIndicatorToDisappear()
     {
-        let query = XCUIApplication().statusBars.childrenMatchingType(.Other).elementBoundByIndex(1).childrenMatchingType(.Other)
+        let app = XCUIApplication()
+        let predicate = NSPredicate(format: "label == 'Network connection in progress'")
+        let element = app.statusBars.childrenMatchingType(.Other).elementBoundByIndex(1).childrenMatchingType(.Other).elementMatchingPredicate(predicate)
         
-        while (query.count > 4) {
+        while (element.exists) {
             sleep(1)
-            print("Number of Elements in Status Bar: \(query.count)... waiting for status bar to disappear")
+            print("Network activity indicator present... waiting for status bar to disappear")
         }
     }
 }


### PR DESCRIPTION
When more than 4 icons are present in the status bar when not loading from the network (e.g. an location service icon), the snaptshot function waits for it to disappear. Optimized the recognition of the network activity indicator view.
