### PR TITLE
Fix for apps with tabbar controller

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -47,8 +47,8 @@ func snapshot(name: String, waitForLoadingIndicator: Bool = true)
         print("snapshot: \(name)") // more information about this, check out https://github.com/krausefx/snapshot
         
         let view = XCUIApplication()
-        let start = view.coordinateWithNormalizedOffset(CGVectorMake(32.10, 30000))
-        let finish = view.coordinateWithNormalizedOffset(CGVectorMake(31, 30000))
+        let start = view.coordinateWithNormalizedOffset(CGVectorMake(32.10, -30000))
+        let finish = view.coordinateWithNormalizedOffset(CGVectorMake(31, -30000))
         start.pressForDuration(0, thenDragToCoordinate: finish)
         sleep(1)
     }


### PR DESCRIPTION
Move offset vertically in the other direction so that in apps with tabbbar controller the current tab is not accidentally changed.
