### PR TITLE
Fixed issue with taking screenshot of screen with alert

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -45,10 +45,12 @@ func snapshot(name: String, waitForLoadingIndicator: Bool = true)
             waitForLoadingIndicatorToDisappear()
         }
         print("snapshot: \(name)") // more information about this, check out https://github.com/krausefx/snapshot
+        let app = XCUIApplication()
+        let alert = app.alerts.element;
+        let targetView = alert.exists ? alert : app
         
-        let view = XCUIApplication()
-        let start = view.coordinateWithNormalizedOffset(CGVectorMake(32.10, 30000))
-        let finish = view.coordinateWithNormalizedOffset(CGVectorMake(31, 30000))
+        let start = targetView.coordinateWithNormalizedOffset(CGVectorMake(32.10, 30000))
+        let finish = targetView.coordinateWithNormalizedOffset(CGVectorMake(31, 30000))
         start.pressForDuration(0, thenDragToCoordinate: finish)
         sleep(1)
     }

--- a/lib/snapshot/collector.rb
+++ b/lib/snapshot/collector.rb
@@ -47,7 +47,7 @@ module Snapshot
               (subtest2["Subtests"] || []).each do |subtest3|
                 (subtest3["ActivitySummaries"] || []).each do |activity|
                   # We now check if it's the drag gesture with a negative value
-                  was_snapshot = activity["Title"].match(/Press and drag from Target Application.*\[32.10.*\].*/)
+                  was_snapshot = activity["Title"].match(/Press and drag from (Target Application|Alert).*\[32.10.*\].*/)
                   activities << activity if was_snapshot
                 end
               end


### PR DESCRIPTION
the issue was - snapshot swipe gesture clicked left button of alert and there was no way to take screenshot of alert. 
This commit adds swipe on alert itself instead of target app.
