### PR TITLE
`launch_arguments` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,14 @@ Here a few links to get started:
 **Swift**
 ```swift
 let app = XCUIApplication()
-setLanguage(app)
+setupSnapshot(app)
 app.launch()
 ```
 
 **Objective C**
 ```objective-c
 XCUIApplication *app = [[XCUIApplication alloc] init];
-[Snapshot setLanguage:app];
+[Snapshot setupSnapshot:app];
 [app launch];
 ```
 
@@ -225,6 +225,8 @@ languages([
   "es-ES"
 ])
 
+launch_arguments("-username Felix")
+
 # The directory in which the screenshots should be stored
 output_directory './screenshots'
 
@@ -254,6 +256,31 @@ snapshot update
 ```
 
 to update your `SnapshotHelper.swift` files. In case you modified your `SnapshotHelper.swift` and want to manually update the file, check out [SnapshotHelper.swift](https://github.com/fastlane/snapshot/blob/master/lib/assets/SnapshotHelper.swift).
+
+## Launch Arguments
+
+You can provide additional arguments to your app on launch. These strings will be available in your code through `NSProcessInfo.processInfo().arguments`. Alternatively use user-default syntax (`-key value`) and they will be available as key-value pairs in `NSUserDefaults.standardUserDefaults()`.
+
+`snapshot` includes `-FASTLANE_SNAPSHOT YES`, which will set a temporary user default for the key `FASTLANE_SNAPSHOT`, you may use this to detect when the app is run by `snapshot`.
+
+```swift
+if NSUserDefaults.standardUserDefaults().boolForKey("FASTLANE_SNAPSHOT") {
+    // runtime check that we are in snapshot mode
+}
+
+username.text = NSUserDefaults.standardUserDefaults().stringForKey("username")
+// username.text = "Felix"
+```
+
+Specify multiple argument strings and `snapshot` will generate screenshots for each combination of arguments, devices, and languages. This is useful for comparing the same screenshots with different feature flags, dynamic text sizes, and different data sets.
+
+```ruby
+# Snapfile for A/B Test Comparison
+launch_arguments([
+  "-secretFeatureEnabled YES",
+  "-secretFeatureEnabled NO"
+])
+```
 
 # How does it work?
 

--- a/example/Example/Base.lproj/Main.storyboard
+++ b/example/Example/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8121.17" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="49e-Tb-3d3">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8101.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <customFonts key="customFonts">
         <mutableArray key="Helvetica.ttc">
@@ -27,13 +27,13 @@
                                 <rect key="frame" x="221" y="279" width="158" height="42"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="36"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loaded by FirstViewController" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A5M-7J-77L">
                                 <rect key="frame" x="203" y="329" width="195" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -46,6 +46,9 @@
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="First" image="first" id="acW-dT-cKf"/>
+                    <connections>
+                        <outlet property="titleLabel" destination="KQZ-1w-vlD" id="GVG-Ui-bu6"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="W5J-7L-Pyd" sceneMemberID="firstResponder"/>
             </objects>
@@ -67,13 +70,13 @@
                                 <rect key="frame" x="195" y="279" width="210" height="42"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="36"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Loaded by SecondViewController" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NDk-cv-Gan">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Loaded by SecondViewController" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NDk-cv-Gan">
                                 <rect key="frame" x="192" y="329" width="216" height="17"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -86,6 +89,9 @@
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Second" image="second" id="cPa-gy-q4n"/>
+                    <connections>
+                        <outlet property="titleLabel" destination="zEq-FU-wV5" id="Dyq-sg-L1p"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4Nw-L8-lE0" sceneMemberID="firstResponder"/>
             </objects>

--- a/example/Example/FirstViewController.m
+++ b/example/Example/FirstViewController.m
@@ -10,13 +10,19 @@
 
 @interface FirstViewController ()
 
+@property (strong, nonatomic) IBOutlet UILabel *titleLabel;
+
 @end
 
 @implementation FirstViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view, typically from a nib.
+    
+    NSString *title = [[NSUserDefaults standardUserDefaults] stringForKey:@"userTitle"];
+    if (title) {
+        self.titleLabel.text = title;
+    }
 }
 
 - (void)didReceiveMemoryWarning {

--- a/example/Example/SecondViewController.m
+++ b/example/Example/SecondViewController.m
@@ -10,13 +10,19 @@
 
 @interface SecondViewController ()
 
+@property (strong, nonatomic) IBOutlet UILabel *titleLabel;
+
 @end
 
 @implementation SecondViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view, typically from a nib.
+    
+    NSString *title = [[NSUserDefaults standardUserDefaults] stringForKey:@"userTitle"];
+    if (title) {
+        self.titleLabel.text = title;
+    }
 }
 
 - (void)didReceiveMemoryWarning {

--- a/example/ExampleUITests/ExampleUITests.swift
+++ b/example/ExampleUITests/ExampleUITests.swift
@@ -16,6 +16,7 @@ class ExampleUITests: XCTestCase {
         
         let app = XCUIApplication()
         setLanguage(app)
+        setLaunchArguments(app)
         app.launch()
     }
     

--- a/lib/assets/SnapfileTemplate
+++ b/lib/assets/SnapfileTemplate
@@ -16,13 +16,8 @@ languages([
   "it-IT"
 ])
 
-# Arguments to pass to the app on launch. Use '-key value' to set NSUserDefaults.
-# launch_arguments("-myUserDefault myValue")
-# or do multiple runs with different arguments
-# launch_arguments([
-#	"-favColor red",
-#   "-favColor blue"
-# ])
+# Arguments to pass to the app on launch. See https://github.com/fastlane/snapshot#launch_arguments
+# launch_arguments("-favColor red")
 
 # The name of the scheme which contains the UI Tests
 # scheme "SchemeName"

--- a/lib/assets/SnapfileTemplate
+++ b/lib/assets/SnapfileTemplate
@@ -16,6 +16,14 @@ languages([
   "it-IT"
 ])
 
+# Arguments to pass to the app on launch. Use '-key value' to set NSUserDefaults.
+# launch_arguments("-myUserDefault myValue")
+# or do multiple runs with different arguments
+# launch_arguments([
+#	"-favColor red",
+#   "-favColor blue"
+# ])
+
 # The name of the scheme which contains the UI Tests
 # scheme "SchemeName"
 

--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -11,17 +11,14 @@ import XCTest
 
 var deviceLanguage = ""
 
+@available(*, deprecated, message="use setupSnapshot: instead")
 func setLanguage(app: XCUIApplication) {
-    Snapshot.setLanguage(app)
-}
-
-func setLaunchArguments(app: XCUIApplication) {
-    Snapshot.setLaunchArguments(app)
+    setupSnapshot(app)
 }
 
 func setupSnapshot(app: XCUIApplication) {
-    setLanguage(app)
-    setLaunchArguments(app)
+    Snapshot.setLanguage(app)
+    Snapshot.setLaunchArguments(app)
 }
 
 func snapshot(name: String, waitForLoadingIndicator: Bool = false) {

--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -21,6 +21,12 @@ func setLaunchArguments(app: XCUIApplication)
     Snapshot.setLaunchArguments(app)
 }
 
+func setupSnapshot(app: XCUIApplication)
+{
+    setLanguage(app)
+    setLaunchArguments(app)
+}
+
 func snapshot(name: String, waitForLoadingIndicator: Bool = true)
 {
     Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator)

--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -45,7 +45,7 @@ func snapshot(name: String, waitForLoadingIndicator: Bool = true)
 
     class func setLaunchArguments(app: XCUIApplication)
     {
-        let path = "/tmp/snapshot-launchArguments.txt"
+        let path = "/tmp/snapshot-launch_arguments.txt"
         
         app.launchArguments += ["-FASTLANE_SNAPSHOT", "1"]
 
@@ -58,7 +58,7 @@ func snapshot(name: String, waitForLoadingIndicator: Bool = true)
             }
             app.launchArguments += results
         } catch {
-            print("Couldn't detect/set launchArguments...")
+            print("Couldn't detect/set launch_arguments...")
         }
     }
     

--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -45,7 +45,7 @@ class Snapshot: NSObject {
     class func setLaunchArguments(app: XCUIApplication) {
         let path = "/tmp/snapshot-launch_arguments.txt"
         
-        app.launchArguments += ["-FASTLANE_SNAPSHOT", "1"]
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES"]
         
         do {
             let launchArguments = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String

--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -47,6 +47,8 @@ func snapshot(name: String, waitForLoadingIndicator: Bool = true)
     {
         let path = "/tmp/snapshot-launchArguments.txt"
         
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "1"]
+
         do {
             let launchArguments = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
             let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])

--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -16,6 +16,11 @@ func setLanguage(app: XCUIApplication)
     Snapshot.setLanguage(app)
 }
 
+func setLaunchArguments(app: XCUIApplication)
+{
+    Snapshot.setLaunchArguments(app)
+}
+
 func snapshot(name: String, waitForLoadingIndicator: Bool = true)
 {
     Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator)
@@ -35,6 +40,23 @@ func snapshot(name: String, waitForLoadingIndicator: Bool = true)
             app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))", "-AppleLocale", "\"\(locale)\"","-ui_testing"]
         } catch {
             print("Couldn't detect/set language...")
+        }
+    }
+
+    class func setLaunchArguments(app: XCUIApplication)
+    {
+        let path = "/tmp/snapshot-launchArguments.txt"
+        
+        do {
+            let launchArguments = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
+            let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+            let matches = regex.matchesInString(launchArguments, options: [], range: NSRange(location:0, length:launchArguments.characters.count))
+            let results = matches.map { result -> String in
+                (launchArguments as NSString).substringWithRange(result.range)
+            }
+            app.launchArguments += results
+        } catch {
+            print("Couldn't detect/set launchArguments...")
         }
     }
     

--- a/lib/snapshot/collector.rb
+++ b/lib/snapshot/collector.rb
@@ -21,6 +21,7 @@ module Snapshot
         FileUtils.mkdir_p(language_folder)
 
         device_name = device_type.delete(" ")
+        # compact filename in case launch arguments has no index
         output_path = File.join(language_folder, [device_name, launch_arguments_index, name].compact.join("-") + ".png")
         from_path = File.join(attachments_path, filename)
         if $verbose

--- a/lib/snapshot/collector.rb
+++ b/lib/snapshot/collector.rb
@@ -1,7 +1,7 @@
 module Snapshot
   # Responsible for collecting the generated screenshots and copying them over to the output directory
   class Collector
-    def self.fetch_screenshots(output, language, device_type)
+    def self.fetch_screenshots(output, language, device_type, launch_arguments_index)
       # Documentation about how this works in the project README
       containing = File.join(TestCommandGenerator.derived_data_path, "Logs", "Test")
       attachments_path = File.join(containing, "Attachments")
@@ -21,7 +21,7 @@ module Snapshot
         FileUtils.mkdir_p(language_folder)
 
         device_name = device_type.delete(" ")
-        output_path = File.join(language_folder, [device_name, name].join("-") + ".png")
+        output_path = File.join(language_folder, [device_name, launch_arguments_index, name].join("-") + ".png")
         from_path = File.join(attachments_path, filename)
         if $verbose
           Helper.log.info "Copying file '#{from_path}' to '#{output_path}'...".green

--- a/lib/snapshot/collector.rb
+++ b/lib/snapshot/collector.rb
@@ -21,7 +21,7 @@ module Snapshot
         FileUtils.mkdir_p(language_folder)
 
         device_name = device_type.delete(" ")
-        output_path = File.join(language_folder, [device_name, launch_arguments_index, name].join("-") + ".png")
+        output_path = File.join(language_folder, [device_name, launch_arguments_index, name].compact.join("-") + ".png")
         from_path = File.join(attachments_path, filename)
         if $verbose
           Helper.log.info "Copying file '#{from_path}' to '#{output_path}'...".green

--- a/lib/snapshot/options.rb
+++ b/lib/snapshot/options.rb
@@ -51,7 +51,9 @@ module Snapshot
                                      env_name: 'SNAPSHOT_LAUNCH_ARGUMENTS',
                                      description: "A list of launch arguments which should be used",
                                      is_string: false,
-                                     optional: true),
+                                     default_value: [
+                                       ''
+                                     ]),
         FastlaneCore::ConfigItem.new(key: :output_directory,
                                      short_option: "-o",
                                      env_name: "SNAPSHOT_OUTPUT_DIRECTORY",

--- a/lib/snapshot/options.rb
+++ b/lib/snapshot/options.rb
@@ -47,13 +47,11 @@ module Snapshot
                                      default_value: [
                                        'en-US'
                                      ]),
-        FastlaneCore::ConfigItem.new(key: :launchArguments,
+        FastlaneCore::ConfigItem.new(key: :launch_arguments,
                                      env_name: 'SNAPSHOT_LAUNCH_ARGUMENTS',
                                      description: "A list of launch arguments which should be used",
                                      is_string: false,
-                                     default_value: [
-                                       ''
-                                     ]),
+                                     optional: true),
         FastlaneCore::ConfigItem.new(key: :output_directory,
                                      short_option: "-o",
                                      env_name: "SNAPSHOT_OUTPUT_DIRECTORY",

--- a/lib/snapshot/options.rb
+++ b/lib/snapshot/options.rb
@@ -47,6 +47,13 @@ module Snapshot
                                      default_value: [
                                        'en-US'
                                      ]),
+        FastlaneCore::ConfigItem.new(key: :launchArguments,
+                                     description: "A list of launch arguments which should be used",
+                                     is_string: false,
+                                     optional: true,
+                                     default_value: [
+                                      ''
+                                     ]),
         FastlaneCore::ConfigItem.new(key: :output_directory,
                                      short_option: "-o",
                                      env_name: "SNAPSHOT_OUTPUT_DIRECTORY",

--- a/lib/snapshot/options.rb
+++ b/lib/snapshot/options.rb
@@ -48,11 +48,11 @@ module Snapshot
                                        'en-US'
                                      ]),
         FastlaneCore::ConfigItem.new(key: :launchArguments,
+                                     env_name: 'SNAPSHOT_LAUNCH_ARGUMENTS',
                                      description: "A list of launch arguments which should be used",
                                      is_string: false,
-                                     optional: true,
                                      default_value: [
-                                      ''
+                                       ''
                                      ]),
         FastlaneCore::ConfigItem.new(key: :output_directory,
                                      short_option: "-o",

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -22,7 +22,7 @@ module Snapshot
 
       self.number_of_retries = 0
       errors = []
-      launch_arguments_set = Snapshot.config[:launchArguments].map.with_index { |e, i| [i, e]}
+      launch_arguments_set = Snapshot.config[:launchArguments].map.with_index { |e, i| [i, e] }
       Snapshot.config[:devices].each do |device|
         launch_arguments_set.each do |launch_arguments|
           Snapshot.config[:languages].each do |language|

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -22,7 +22,7 @@ module Snapshot
 
       self.number_of_retries = 0
       errors = []
-      launch_arguments_set = Snapshot.config[:launchArguments].map.with_index { |e, i| [i, e] }
+      launch_arguments_set = config_launch_arguments
       Snapshot.config[:devices].each do |device|
         launch_arguments_set.each do |launch_arguments|
           Snapshot.config[:languages].each do |language|
@@ -42,6 +42,15 @@ module Snapshot
 
       # Generate HTML report
       ReportsGenerator.new.generate
+    end
+
+    def config_launch_arguments
+      launch_arguments = Array(Snapshot.config[:launchArguments])
+      if (launch_arguments.count == 1)
+        [launch_arguments]
+      else
+        launch_arguments.map.with_index { |e, i| [i, e] }
+      end
     end
 
     def launch(language, device_type, launch_arguments)

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -46,7 +46,7 @@ module Snapshot
 
     def config_launch_arguments
       launch_arguments = Array(Snapshot.config[:launchArguments])
-      if (launch_arguments.count == 1)
+      if launch_arguments.count == 1
         [launch_arguments]
       else
         launch_arguments.map.with_index { |e, i| [i, e] }

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -45,7 +45,8 @@ module Snapshot
     end
 
     def config_launch_arguments
-      launch_arguments = Array(Snapshot.config[:launchArguments])
+      launch_arguments = Array(Snapshot.config[:launch_arguments])
+      # if more than 1 set of arguments, use a tuple with an index
       if launch_arguments.count == 1
         [launch_arguments]
       else
@@ -59,7 +60,7 @@ module Snapshot
       FileUtils.mkdir_p(screenshots_path)
 
       File.write("/tmp/language.txt", language)
-      File.write("/tmp/snapshot-launchArguments.txt", launch_arguments.last)
+      File.write("/tmp/snapshot-launch_arguments.txt", launch_arguments.last)
 
       command = TestCommandGenerator.generate(device_type: device_type)
 

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -72,7 +72,7 @@ module Snapshot
 
       command = TestCommandGenerator.generate(device_type: device_type)
 
-      Helper.log_alert("#{device_type} - #{language} - #{launch_arguments.last}")
+      Helper.log_alert("#{device_type} - #{language}")
 
       prefix_hash = [
         {


### PR DESCRIPTION
Adds an optional setting to the _Snapfile_ for a list of launch arguments.
Like `languages` or `devices`, each item in `launchArguments` will multiply the number of screenshot sets you get. (This could be reduced with a build matrix).

Launch Arguments are useful if you want to run tests with different sets of `NSUserDefaults`, for example to toggle feature flags, or to override the Dynamic Type size.
Snapshot already uses launch arguments to set the language - now you can use any set of arguments you wish.

ruby style comments are very much welcome
