### PR TITLE
Updated links to fixes to show the real radar numbers

### DIFF
--- a/lib/snapshot/fixes/README.md
+++ b/lib/snapshot/fixes/README.md
@@ -1,5 +1,5 @@
 ### Fixes
 
 This directory contains all the files we don't actually want to have, but are necessary due to open radars, e.g.
-- [#5056366381105152](https://openradar.appspot.com/radar?id=5056366381105152): Trigger screenshots from UI Tests
-- [#6127019184095232](https://openradar.appspot.com/radar?id=6127019184095232): Screenshots are broken when simulator is not scaled at 100%
+- [rdar://23062925](https://openradar.appspot.com/radar?id=5056366381105152): Trigger screenshots from UI Tests
+- [rdar://23323159](https://openradar.appspot.com/radar?id=6127019184095232): Screenshots are broken when simulator is not scaled at 100%


### PR DESCRIPTION
The previous number was just some internal _openradar.me_ ID :)
