### PR TITLE
Orientation grouping

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -38,7 +38,8 @@ class Snapshot: NSObject {
             waitForLoadingIndicatorToDisappear()
         }
         
-        print("snapshot: \(name)") // more information about this, check out https://github.com/krausefx/snapshot
+        let orientation = XCUIDevice.sharedDevice().orientation.isPortrait ? "portrait" : "landscape"
+        print("snapshot: \(name)-\(orientation)") // more information about this, check out https://github.com/krausefx/snapshot
         
         sleep(1) // Waiting for the animation to be finished (kind of)
         XCUIDevice.sharedDevice().orientation = .Unknown
@@ -56,4 +57,4 @@ class Snapshot: NSObject {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [[1.0]]
+// SnapshotHelperVersion [[1.1]]

--- a/lib/snapshot/reports_generator.rb
+++ b/lib/snapshot/reports_generator.rb
@@ -13,20 +13,20 @@ module Snapshot
       Dir[File.join(screens_path, "*")].sort.each do |language_folder|
         language = File.basename(language_folder)
         Dir[File.join(language_folder, '*.png')].sort.each do |screenshot|
-       	   ["portrait", "landscape"].each do |orientation|	
-	          available_devices.each do |key_name, output_name|
-    	        next unless File.basename(screenshot).include?key_name
-				  if File.basename(screenshot).include?orientation
-              		output_name += " (#{orientation.capitalize})"
-              	  end
-        	    # This screenshot is from this device
-            	@data[language] ||= {}
-            	@data[language][output_name] ||= []
+          ["portrait", "landscape"].each do |orientation|
+            available_devices.each do |key_name, output_name|
+              next unless File.basename(screenshot).include? key_name
+              if File.basename(screenshot).include? orientation
+                output_name += " (#{orientation.capitalize})"
+              end
+              # This screenshot is from this device
+              @data[language] ||= {}
+              @data[language][output_name] ||= []
 
-            	resulting_path = File.join('.', language, File.basename(screenshot))
-            	@data[language][output_name] << resulting_path
-            	break # to not include iPhone 6 and 6 Plus (name is contained in the other name)
-          	end
+              resulting_path = File.join('.', language, File.basename(screenshot))
+              @data[language][output_name] << resulting_path
+              break # to not include iPhone 6 and 6 Plus (name is contained in the other name)
+            end
           end
         end
       end

--- a/lib/snapshot/reports_generator.rb
+++ b/lib/snapshot/reports_generator.rb
@@ -13,13 +13,12 @@ module Snapshot
       Dir[File.join(screens_path, "*")].sort.each do |language_folder|
         language = File.basename(language_folder)
         Dir[File.join(language_folder, '*.png')].sort.each do |screenshot|
-        ["portrait", "landscape"].each do |orientation|
-        	  if File.basename(screenshot).include?orientation
-              	output_name += " (#{orientation.capitalize})"
-              end	
+       	   ["portrait", "landscape"].each do |orientation|	
 	          available_devices.each do |key_name, output_name|
     	        next unless File.basename(screenshot).include?key_name
-
+				  if File.basename(screenshot).include?orientation
+              		output_name += " (#{orientation.capitalize})"
+              	  end
         	    # This screenshot is from this device
             	@data[language] ||= {}
             	@data[language][output_name] ||= []

--- a/lib/snapshot/reports_generator.rb
+++ b/lib/snapshot/reports_generator.rb
@@ -13,16 +13,21 @@ module Snapshot
       Dir[File.join(screens_path, "*")].sort.each do |language_folder|
         language = File.basename(language_folder)
         Dir[File.join(language_folder, '*.png')].sort.each do |screenshot|
-          available_devices.each do |key_name, output_name|
-            next unless File.basename(screenshot).include?(key_name)
+        ["portrait", "landscape"].each do |orientation|
+        	  if File.basename(screenshot).include?orientation
+              	output_name += " (#{orientation.capitalize})"
+              end	
+	          available_devices.each do |key_name, output_name|
+    	        next unless File.basename(screenshot).include?key_name
 
-            # This screenshot is from this device
-            @data[language] ||= {}
-            @data[language][output_name] ||= []
+        	    # This screenshot is from this device
+            	@data[language] ||= {}
+            	@data[language][output_name] ||= []
 
-            resulting_path = File.join('.', language, File.basename(screenshot))
-            @data[language][output_name] << resulting_path
-            break # to not include iPhone 6 and 6 Plus (name is contained in the other name)
+            	resulting_path = File.join('.', language, File.basename(screenshot))
+            	@data[language][output_name] << resulting_path
+            	break # to not include iPhone 6 and 6 Plus (name is contained in the other name)
+          	end
           end
         end
       end


### PR DESCRIPTION
This request adds grouping of generated screenshots by orientation feature, which was dropped in 1.0 release. 
One thing I'm not sure about is snapshot helper update required detection. 
I've updated helper and incremented it's version in the end of file, but didn't have a chance to check this
