### PR TITLE
Orientation grouping

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -66,11 +66,26 @@ class Snapshot: NSObject {
         if waitForLoadingIndicator {
             waitForLoadingIndicatorToDisappear()
         }
-
-        print("snapshot: \(name)") // more information about this, check out https://github.com/fastlane/snapshot
-
+        
+        let orientation = detectDeviceOrientation()
+        print("snapshot: \(name)-\(orientation.isPortrait ? "portrait" : "landscape")")  // more information about this, check out https://github.com/krausefx/snapshot
+        
         sleep(1) // Waiting for the animation to be finished (kind of)
         XCUIDevice.sharedDevice().orientation = .Unknown
+        //this speeds up orientation detect on next snapshot calls
+        XCUIDevice.sharedDevice().orientation = orientation
+    }
+    
+    class func detectDeviceOrientation() -> UIDeviceOrientation{
+        let orientation = XCUIDevice.sharedDevice().orientation
+        if orientation.isValidInterfaceOrientation{
+            return orientation
+        }
+        
+        //this is slightly hackish solution, but because of setting .Unknown orientation for snapshot, dealing with orientation is pretty complicated
+        let coordinate = XCUIApplication().windows.elementBoundByIndex(0)
+            .coordinateWithNormalizedOffset(CGVectorMake(1.0, 1.0)).screenPoint
+        return coordinate.x < coordinate.y ? .Portrait : .LandscapeLeft
     }
 
     class func waitForLoadingIndicatorToDisappear() {

--- a/lib/snapshot/reports_generator.rb
+++ b/lib/snapshot/reports_generator.rb
@@ -16,6 +16,11 @@ module Snapshot
           available_devices.each do |key_name, output_name|
             next unless File.basename(screenshot).include?(key_name)
 
+            ["portrait", "landscape"].each do |orientation|
+              if File.basename(screenshot).include? orientation
+                output_name += " (#{orientation.capitalize})"
+              end
+            end
             # This screenshot is from this device
             @data[language] ||= {}
             @data[language][output_name] ||= []


### PR DESCRIPTION
Really sorry for screenshots duplication issue in #335. This pull request fixes that and now all should work fine. As for me it works :)

Also this will setup valid `UIDeviceOrientation` after calling snapshot. Because previously - orientation was still `.Unknown` even after simulator reboot.
