### PR TITLE
Trim whitespace & newlines in locale string

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -37,7 +37,8 @@ class Snapshot: NSObject {
         let path = "/tmp/language.txt"
 
         do {
-            deviceLanguage = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
+            let trimCharacterSet = NSCharacterSet.whitespaceAndNewlineCharacterSet()
+            deviceLanguage = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding).stringByTrimmingCharactersInSet(trimCharacterSet) as String
             app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
         } catch {
             print("Couldn't detect/set language...")
@@ -48,7 +49,8 @@ class Snapshot: NSObject {
         let path = "tmp/locale.txt"
 
         do {
-            locale = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
+            let trimCharacterSet = NSCharacterSet.whitespaceAndNewlineCharacterSet()
+            locale = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding).stringByTrimmingCharactersInSet(trimCharacterSet) as String
         } catch {
             print("Couldn't detect/set locale...")
         }


### PR DESCRIPTION
The issue mentioned in #343 is most likely caused due to a new line in the "/tmp/language.txt" file. At least this is what happened to me when manually editing the file & trying to run tests in Xcode. A newline at the end of locale string caused the AppleLocale parameter to be split into two lines which prevented the simulator to apply the correct locale to the app and falling back to "en_US". Trimming new lines fixes this issue.
