### PR TITLE
Open locale from outside of SnapshotHelper

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -10,6 +10,7 @@ import Foundation
 import XCTest
 
 var deviceLanguage = ""
+var locale = ""
 
 @available(*, deprecated, message="use setupSnapshot: instead")
 func setLanguage(app: XCUIApplication) {
@@ -35,7 +36,7 @@ class Snapshot: NSObject {
         let path = "/tmp/language.txt"
 
         do {
-            let locale = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
+            locale = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
             deviceLanguage = locale.substringToIndex(locale.startIndex.advancedBy(2, limit:locale.endIndex))
             app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))", "-AppleLocale", "\"\(locale)\"", "-ui_testing"]
         } catch {


### PR DESCRIPTION
This helps getting the full locale name from within the UI-Tests. It was critical for the screenshots that are used in my company and probably will be really useful for someone else. We have to take different screenshots for different regions, for example:

For es-MX we show Mexico City on the screenshot,
For es-ES we show Barcelona on the screenshot,
For es-CH we show something else.

We achieved it this way and I wanted to share this solution with everyone else.
