### PR TITLE
Improved language and locale handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ devices([
 languages([
   "en-US",
   "de-DE",
-  "es-ES"
+  "es-ES",
+  ["pt", "pt_BR"] # Portuguese with Brazilian locale
 ])
 
 launch_arguments("-username Felix")
@@ -352,6 +353,8 @@ If you want to add frames around the screenshots and even put a title on top, ch
 ```ruby
 ALL_LANGUAGES = ["da", "de-DE", "el", "en-AU", "en-CA", "en-GB", "en-US", "es-ES", "es-MX", "fi", "fr-CA", "fr-FR", "id", "it", "ja", "ko", "ms", "nl", "no", "pt-BR", "pt-PT", "ru", "sv", "th", "tr", "vi", "zh-Hans", "zh-Hant"]
 ```
+
+To get more information about language and locale codes please read [Internationalization and Localization Guide](https://developer.apple.com/library/ios/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html).
 
 ## Use a clean status bar
 You can use [SimulatorStatusMagic](https://github.com/shinydevelopment/SimulatorStatusMagic) to clean up the status bar.

--- a/lib/assets/SnapfileTemplate
+++ b/lib/assets/SnapfileTemplate
@@ -13,7 +13,8 @@
 languages([
   "en-US",
   "de-DE",
-  "it-IT"
+  "it-IT",
+  ["pt", "pt_BR"] # Portuguese with Brazilian locale
 ])
 
 # Arguments to pass to the app on launch. See https://github.com/fastlane/snapshot#launch-arguments

--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -29,6 +29,7 @@ class Snapshot: NSObject {
 
     class func setupSnapshot(app: XCUIApplication) {
         setLanguage(app)
+        setLocale(app)
         setLaunchArguments(app)
     }
 
@@ -36,18 +37,31 @@ class Snapshot: NSObject {
         let path = "/tmp/language.txt"
 
         do {
-            locale = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
-            deviceLanguage = locale.substringToIndex(locale.startIndex.advancedBy(2, limit:locale.endIndex))
-            app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))", "-AppleLocale", "\"\(locale)\"", "-ui_testing"]
+            deviceLanguage = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
+            app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
         } catch {
             print("Couldn't detect/set language...")
         }
     }
 
+    class func setLocale(app: XCUIApplication) {
+        let path = "tmp/locale.txt"
+
+        do {
+            locale = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
+        } catch {
+            print("Couldn't detect/set locale...")
+        }
+        if locale.isEmpty {
+            locale = NSLocale(localeIdentifier: deviceLanguage).localeIdentifier
+        }
+        app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+    }
+
     class func setLaunchArguments(app: XCUIApplication) {
         let path = "/tmp/snapshot-launch_arguments.txt"
 
-        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES"]
+        app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
 
         do {
             let launchArguments = try NSString(contentsOfFile: path, encoding: NSUTF8StringEncoding) as String
@@ -91,4 +105,4 @@ extension XCUIElement {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [[1.0]]
+// SnapshotHelperVersion [[1.1]]


### PR DESCRIPTION
Hi,

Currently, user provides list of languages which are then converted to "generic language id"[[*](https://developer.apple.com/library/ios/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html)] and the provided language is used as locale value. It is not the best approach, because "different" languages like `pt-PT` and `pt-BR` are treated as the same language `pt` (`-AppleLanguages "(pt)"`) with different locale (`-AppleLocale "pt-BR"`), which can cause problems like #422 and #396. Better approach would be to use language that the user provided (i.e. `pt-BR`) and "guess" locale for the given language. Right now Xcode doesn't guess locale value when the language was selected in the scheme options, it just use the same value for language and locale. I think that `snapshot` should not be smarter here and use the same approach. But it should also allows to select locale different than language.

In this PR, I've fixed issue (I hope :wink: ) with device languages #422 and #396 and added possibility to provide locale next to language:

``` ruby
languages([
  "en-US",
  ["fr", "fr_CA"], # French language with French Canadian locale
  "de-DE"
])
```
