### PR TITLE
Bump the ruby versions used on CI to latest bugfix versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ before_install:
   - gem update --system
   - gem install bundler
 rvm:
-  - 2.1.6
-  - 2.2.2
+  - 2.1.8
+  - 2.2.4
 script: bundle exec fastlane test


### PR DESCRIPTION
This was mostly a test to determine if a newer Ruby version would prevent the 2.2.x CI machine from hanging endlessly. It didn't work.

In any case, is it worth bumping these versions across all the repos, @KrauseFx?
