### PR TITLE
Fixed `reset_simulators` command.

### DIFF
--- a/bin/snapshot
+++ b/bin/snapshot
@@ -65,8 +65,8 @@ class SnapshotApplication
       c.option '-i', '--ios String', String, 'The comma separated list of iOS Versions you want to use'
 
       c.action do |args, options|
-        versions = [Snapshot::LatestIosVersion.version]
-        versions = options.ios.split(',') if options.ios
+        options.default ios_version: Snapshot::LatestIosVersion.version
+        versions = options.ios_version.split(',') if options.ios_version
         require 'snapshot/reset_simulators'
 
         Snapshot::ResetSimulators.clear_everything!(versions)


### PR DESCRIPTION
Hi,

From some time `reset_simulators` stops accepting list of iOS version to install / reset. Problem occurs because of "some" conflicts between the `--ios_version` argument of `snapshot` command and the `--ios` argument of the `reset_simulators` subcommand. They both have the same short version `-i`. Because of this conflict, when user provides `-i` then the list of the version is stored in the `:ios_version` variable. When `--ios` is used, the versions are stored in the `:ios` and the `:ios_version` variable.
