### PR TITLE
Improved multiprocess support.

### DIFF
--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -34,7 +34,11 @@ class Snapshot: NSObject {
     }
 
     class func setLanguage(app: XCUIApplication) {
-        let path = "/tmp/language.txt"
+        guard let prefix = pathPrefix() else {
+            return
+        }
+
+        let path = prefix.stringByAppendingPathComponent("language.txt")
 
         do {
             let trimCharacterSet = NSCharacterSet.whitespaceAndNewlineCharacterSet()
@@ -46,7 +50,11 @@ class Snapshot: NSObject {
     }
 
     class func setLocale(app: XCUIApplication) {
-        let path = "tmp/locale.txt"
+        guard let prefix = pathPrefix() else {
+            return
+        }
+
+        let path = prefix.stringByAppendingPathComponent("locale.txt")
 
         do {
             let trimCharacterSet = NSCharacterSet.whitespaceAndNewlineCharacterSet()
@@ -61,8 +69,11 @@ class Snapshot: NSObject {
     }
 
     class func setLaunchArguments(app: XCUIApplication) {
-        let path = "/tmp/snapshot-launch_arguments.txt"
+        guard let prefix = pathPrefix() else {
+            return
+        }
 
+        let path = prefix.stringByAppendingPathComponent("snapshot-launch_arguments.txt")
         app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
 
         do {
@@ -97,6 +108,14 @@ class Snapshot: NSObject {
             print("Waiting for loading indicator to disappear...")
         }
     }
+
+    class func pathPrefix() -> NSString? {
+        if let path = NSProcessInfo().environment["SIMULATOR_HOST_HOME"] as NSString? {
+            return path.stringByAppendingPathComponent("Library/Caches/tools.fastlane")
+        }
+        print("Couldn't find Snapshot configuration files at ~/Library/Caches/tools.fastlane")
+        return nil
+    }
 }
 
 extension XCUIElement {
@@ -107,4 +126,4 @@ extension XCUIElement {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.1]
+// SnapshotHelperVersion [1.2]

--- a/lib/snapshot.rb
+++ b/lib/snapshot.rb
@@ -25,9 +25,12 @@ module Snapshot
 
     attr_accessor :project
 
+    attr_accessor :cache
+
     def config=(value)
       @config = value
       DetectValues.set_additional_default_values
+      @cache = {}
     end
 
     def snapfile_name

--- a/lib/snapshot/runner.rb
+++ b/lib/snapshot/runner.rb
@@ -115,9 +115,11 @@ module Snapshot
       FileUtils.rm_rf(screenshots_path) if Snapshot.config[:clean]
       FileUtils.mkdir_p(screenshots_path)
 
-      File.write("/tmp/language.txt", language)
-      File.write("/tmp/locale.txt", locale || "")
-      File.write("/tmp/snapshot-launch_arguments.txt", launch_arguments.last)
+      prefix = File.join(Dir.home, "Library/Caches/tools.fastlane")
+      FileUtils.mkdir_p(prefix)
+      File.write(File.join(prefix, "language.txt"), language)
+      File.write(File.join(prefix, "locale.txt"), locale || "")
+      File.write(File.join(prefix, "snapshot-launch_arguments.txt"), launch_arguments.last)
 
       Fixes::SimulatorZoomFix.patch
       Fixes::HardwareKeyboardFix.patch

--- a/lib/snapshot/test_command_generator.rb
+++ b/lib/snapshot/test_command_generator.rb
@@ -88,7 +88,7 @@ module Snapshot
       end
 
       def derived_data_path
-        "/tmp/snapshot_derived/"
+        Snapshot.cache[:derived_data_path] ||= Dir.mktmpdir("snapshot_derived")
       end
     end
   end

--- a/spec/test_command_generator_spec.rb
+++ b/spec/test_command_generator_spec.rb
@@ -7,6 +7,7 @@ describe Snapshot do
       end
 
       it "uses the default parameters" do
+        expect(Dir).to receive(:mktmpdir).with("snapshot_derived").and_return("/tmp/path/to/snapshot_derived")
         command = Snapshot::TestCommandGenerator.generate(device_type: "Something")
         ios = command.join('').match(/OS=(\d+.\d+)/)[1]
         expect(command).to eq([
@@ -14,7 +15,7 @@ describe Snapshot do
           "xcodebuild",
           "-scheme 'ExampleUITests'",
           "-project './example/Example.xcodeproj'",
-          "-derivedDataPath '/tmp/snapshot_derived/'",
+          "-derivedDataPath '/tmp/path/to/snapshot_derived'",
           "-destination 'platform=iOS Simulator,id=,OS=#{ios}'",
           :build,
           :test,


### PR DESCRIPTION
Hi,

Currently `snapshot` stores the "settings" files like the `language.txt` in the global `/tmp` folder. Because of this `snapshot` can be run only by one user at the same time on the Mac. If someone has Continuous Integration server, like Jenkins, and wants to use two user accounts, the "settings" files have to be placed in another directory. I suggest to use per user cache directory (`~/Library/Cache`). This is what I've done in this pull request.
