### PR TITLE
Prevent alerts to be captured

### DIFF
--- a/lib/assets/SnapshotAlertManager.swift
+++ b/lib/assets/SnapshotAlertManager.swift
@@ -1,0 +1,60 @@
+//
+//  SnapshotAlertManager.swift
+//
+//  Created by Maxime Britto on 06/01/2016.
+//  Copyright © 2016 dev2a. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+func automaticallyDismissAlerts(testCase:XCTestCase) -> NSObjectProtocol {
+    return SnapshotAlertManager.automaticallyDismissAlerts(testCase)
+}
+
+func stopDismissingAlerts(testCase:XCTestCase) {
+    SnapshotAlertManager.stopDismissingAlerts(testCase)
+}
+
+func waitForAlertsToBeDismissed() {
+    SnapshotAlertManager.waitForAlertsToBeDismissed()
+}
+
+class SnapshotAlertManager: NSObject {
+    static var alertInterruptionMonitor:NSObjectProtocol?
+
+    class func stopDismissingAlerts(testCase:XCTestCase) {
+        if let previousDismissHandler = alertInterruptionMonitor {
+            testCase.removeUIInterruptionMonitor(previousDismissHandler)
+        }
+    }
+
+    class func automaticallyDismissAlerts(testCase:XCTestCase) -> NSObjectProtocol
+    {
+        SnapshotAlertManager.stopDismissingAlerts(testCase)
+        alertInterruptionMonitor = testCase.addUIInterruptionMonitorWithDescription("Snapshot alert auto hide") { (alert: XCUIElement) -> Bool in
+            print("Alert \"\(alert.label)\" will be dismissed")
+            return false
+        }
+
+        return alertInterruptionMonitor!
+    }
+
+    class func waitForAlertsToBeDismissed()
+    {
+        let query = XCUIApplication().alerts
+        var waitCounter = 0
+        while (query.count > 0) {
+            sleep(1)
+            waitCounter++
+            print("Found an alert... waiting for it to disappear")
+            if waitCounter > 2 {
+              if alertInterruptionMonitor == nil {
+                  print("The SnapshotAlertManager can automatically hide alerts that will prevent actions or screenshots. Just call this method to enable it : automaticallyDismissAlerts(testCase:XCTestCase)")
+              } else {
+                  XCUIApplication().tap() //UIInterruptionMonitor will only trigger if an action is prevented by the alert so we generate one if the user script hasn't after 2 seconds
+              }
+            }
+        }
+    }
+}

--- a/lib/assets/SnapshotHelper.swift
+++ b/lib/assets/SnapshotHelper.swift
@@ -21,8 +21,8 @@ func setupSnapshot(app: XCUIApplication) {
     Snapshot.setupSnapshot(app)
 }
 
-func snapshot(name: String, waitForLoadingIndicator: Bool = true) {
-    Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator)
+func snapshot(name: String, waitForLoadingIndicator: Bool = true, waitForAlerts: Bool = true) {
+    Snapshot.snapshot(name, waitForLoadingIndicator: waitForLoadingIndicator, waitForAlerts: waitForAlerts)
 }
 
 class Snapshot: NSObject {
@@ -76,9 +76,13 @@ class Snapshot: NSObject {
         }
     }
 
-    class func snapshot(name: String, waitForLoadingIndicator: Bool = true) {
+    class func snapshot(name: String, waitForLoadingIndicator: Bool = true, waitForAlerts: Bool = true) {
         if waitForLoadingIndicator {
             waitForLoadingIndicatorToDisappear()
+        }
+
+        if waitForAlerts {
+            waitForAlertsToBeDismissed()
         }
 
         print("snapshot: \(name)") // more information about this, check out https://github.com/fastlane/snapshot

--- a/lib/snapshot/setup.rb
+++ b/lib/snapshot/setup.rb
@@ -11,13 +11,15 @@ module Snapshot
       gem_path = Helper.gem_path("snapshot")
       File.write(snapfile_path, File.read("#{gem_path}/lib/assets/SnapfileTemplate"))
       File.write(File.join(path, 'SnapshotHelper.swift'), File.read("#{gem_path}/lib/assets/SnapshotHelper.swift"))
+      File.write(File.join(path, 'SnapshotAlertManager.swift'), File.read("#{gem_path}/lib/assets/SnapshotAlertManager.swift"))
 
       puts "Successfully created SnapshotHelper.swift '#{File.join(path, 'SnapshotHelper.swift')}'".green
+      puts "Successfully created SnapshotAlertManager.swift '#{File.join(path, 'SnapshotAlertManager.swift')}'".green
       puts "Successfully created new Snapfile at '#{snapfile_path}'".green
 
       puts "-------------------------------------------------------".yellow
       puts "Open your Xcode project and make sure to do the following:".yellow
-      puts "1) Add the ./fastlane/SnapshotHelper.swift to your UI Test target".yellow
+      puts "1) Add the ./fastlane/SnapshotHelper.swift and ./fastlane/SnapshotAlertManager.swift to your UI Test target".yellow
       puts "   You can move the file anywhere you want".yellow
       puts "2) Call `setupSnapshot(app)` when launching your app".yellow
       puts ""
@@ -26,6 +28,8 @@ module Snapshot
       puts "  app.launch()"
       puts ""
       puts "3) Add `snapshot(\"0Launch\")` to wherever you want to create the screenshots".yellow
+      puts ""
+      puts "4) Optional : You can ask snapshot to automatically dismiss any alert that gets in the way of your actions/snapshots by calling automaticallyDismissAlerts(self) once in your test code".yellow
       puts ""
       puts "More information on GitHub: https://github.com/fastlane/snapshot".green
     end


### PR DESCRIPTION
- Calls to the snapshot() function will now wait until all alert have
  disappeared before taking the screenshot (can be disabled with a
  boolean parameter on the snapshot() method)
- Adds a function to allow automatic dismissal of alerts that prevent
  actions or snapshots
- Copy the new SnapshotAlertManagement.swift file to the same place as
  the SnapshotHelper.swift file during original setup
